### PR TITLE
Update team name in codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*    @circleci/mktg-web-optimizations
+*    @circleci/web-development-optimizations


### PR DESCRIPTION
**Ticket:** [WEB-1842](https://circleci.atlassian.net/browse/WEB-1842)

## Changes
* Update team name to match new name: https://github.com/orgs/circleci/teams/web-development-optimizations

## Rationale
The team name has been changed on Github.

## Considerations
Similar change to 
* https://github.com/circleci/circleci.com/pull/7206
* https://github.com/circleci/circleci.com-blog/pull/365
* https://github.com/circleci/circleci.com-next/pull/88

## How to test
View the codeowners file on this branch and see that it is valid
https://github.com/circleci/jekyll-assets/blob/update-codeowner/.github/CODEOWNERS

## Screenshots
### Before
<img width="521" alt="Screenshot 2024-02-20 at 10 02 58 AM" src="https://github.com/envygeeks/jekyll-assets/assets/5113432/ebd1fda3-9072-4c2e-ad7b-da35c459c391">


<img width="726" alt="Screenshot 2024-02-20 at 9 58 21 AM" src="https://github.com/circleci/circleci.com-next/assets/5113432/8214cddc-6173-4879-9e97-c65e1b77cb66">


### After

<img width="522" alt="Screenshot 2024-02-20 at 10 05 57 AM" src="https://github.com/envygeeks/jekyll-assets/assets/5113432/8b046cc4-4b07-4044-9be4-3dd0df5470bf">


[WEB-1842]: https://circleci.atlassian.net/browse/WEB-1842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ